### PR TITLE
jianchang update docs

### DIFF
--- a/zh/02-install/01-overview.md
+++ b/zh/02-install/01-overview.md
@@ -1,0 +1,19 @@
+---
+title: 简介
+---
+
+本章介绍 MetaFlow 的部署方法。MetaFlow 可用于监控多个 K8s 上的容器应用、多个 VPC 中的云主机应用。本章的内容安排如下：
+- [all-in-one](./all-in-one/)：使用一台虚拟机快速体验 MetaFlow
+- [single-k8s](./single-k8s/)：部署 MetaFlow 监控一个 K8s 集群上的所有应用，所有观测数据将会自动注入`K8s 资源`和`K8s 自定义 Label`标签
+- [multi-k8s](./multi-k8s/)：部署 MetaFlow 监控多个 K8s 集群上的所有应用
+- [legacy-host](./legacy-host/)：部署 MetaFlow 监控传统服务器上的所有应用
+- [cloud-host](./cloud-host)：部署 MetaFlow 监控云服务器上的所有应用，所有观测数据将会自动注入`云资源`标签
+- [managed-k8s](./managed-k8s)：部署 MetaFlow 监控云服务商托管 K8s 集群上的所有应用，所有观测数据将会自动注入`云资源`、`K8s 资源`、`K8s 自定义 Label`标签
+
+如果你现在没有合适的资源部署 MetaFlow，也可登录我们的[在线 Demo](https://demo.metaflow.yunshan.net)（用户名/密码均为 `metaflow`），
+借助如下文档章节抢先体验 MetaFlow 的强大能力：
+- [自动分布式追踪 - 体验 MetaFlow 基于 eBPF 的 AutoTracing 能力](../auto-tracing/overview/)
+- [微服务全景图 - 体验 MetaFlow 基于 BPF 的 AutoMetrics 能力](../auto-metrics/overview/)
+- [消除数据孤岛 - 了解 MetaFlow 的 AutoTagging 和 SmartEncoding 能力](../auto-tagging/elimilate-data-silos/)
+- [无缝分布式追踪 - 集成 OpenTelemetry 等追踪数据](../agent-integration/tracing/overview/)
+- [告别高基烦恼 - 集成 Promethes 等指标数据](../agent-integration/metrics/overview/)

--- a/zh/02-install/02-all-in-one.md
+++ b/zh/02-install/02-all-in-one.md
@@ -4,7 +4,7 @@ title: All-in-One 快速部署
 
 # 简介
 
-虽然 metaflow-agent 可运行于各种环境中，但 metaflow-server 仅能运行在 K8s 之上。因此本章我们从一个 All-in-One K8s 集群出发，介绍如何部署一个 MetaFlow 的体验环境。
+虽然 metaflow-agent 可运行于各种环境中，但 metaflow-server 必须运行在 K8s 之上。本章我们从一个 All-in-One K8s 集群出发，介绍如何部署一个 MetaFlow 的体验环境。
 
 # 准备工作
 
@@ -53,6 +53,10 @@ helm repo update metaflow # use `helm repo update` when helm < 3.7.0
 helm install metaflow -n metaflow metaflow/metaflow --create-namespace \
     --set global.allInOneLocalStorage=true
 ```
+
+# 访问 Grafana 页面
+
+@建昌
 
 # 下一步
 

--- a/zh/02-install/03-single-k8s.md
+++ b/zh/02-install/03-single-k8s.md
@@ -43,7 +43,7 @@ end
 
 ## Storage Class
 
-我们建议使用 Persistent Volumes 来保存 mysql 和 clickhouse 的数据，以避免不必要的维护成本。
+我们建议使用 Persistent Volumes 来保存 MySQL 和 Clickhouse 的数据，以避免不必要的维护成本。
 你可以提供默认 Storage Class 或添加 `--set global.storageClass=<your storageClass>` 参数来选择 Storage Class 以创建 PVC。
 
 可选择 [OpenEBS](https://openebs.io/) 用于创建 PVC：
@@ -108,7 +108,18 @@ chmod a+x /usr/bin/metaflow-ctl
 
 # 访问 Grafana 页面
 
-@建昌
+执行 helm 部署 metaflow 时输出的命令，获取访问 Grafana 的 URL 和密码，输出示例：
+
+```bash
+NODE_PORT=$(kubectl get --namespace metaflow -o jsonpath="{.spec.ports[0].nodePort}" services metaflow-grafana)
+NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+echo -e "Grafana URL: http://$NODE_IP:$NODE_PORT  \nGrafana auth: metaflow"
+```
+执行命令输出示例：
+```text
+Grafana URL: http://10.1.2.3:31999
+Grafana auth: admin:metaflow
+```
 
 # 下一步
 

--- a/zh/02-install/03-single-k8s.md
+++ b/zh/02-install/03-single-k8s.md
@@ -4,7 +4,9 @@ title: 监控单个 K8s 集群
 
 # 简介
 
-假如你在一个 K8s 集群中部署了应用，本章介绍如何使用 MetaFlow 进行监控。MetaFlow 能够自动采集所有 Pod 的应用和网络观测数据（AutoMetrics、AutoTracing），并基于调用 apiserver 获取的信息自动为所有观测数据注入容器资源和自定义 Label 标签（AutoTagging）。
+假如你在一个 K8s 集群中部署了应用，本章介绍如何使用 MetaFlow 进行监控。
+MetaFlow 能够自动采集所有 Pod 的应用和网络观测数据（AutoMetrics、AutoTracing），
+并基于调用 apiserver 获取的信息自动为所有观测数据注入`K8s 资源`和`K8s 自定义 Label`标签（AutoTagging）。
 
 # 准备工作
 
@@ -51,16 +53,16 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
 
 ## metaflow-agent 权限需求
 
-metaflow-agent 需要的容器节点权限如下：
+metaflow-agent 要求所在容器节点的配置如下：
+- `selinux` = `Permissive` OR `disabled`
+
+metaflow-agent 作为 DaemonSet 部署时将会打开它的如下权限：
 - `hostNetwork`
 - `hostPID`
 - `privileged`
 - Write `/sys/kernel/debug`
 
-metaflow-agent 需要的容器节点配置如下：
-- `selinux` = `Permissive` OR `disabled`
-  
-metaflow-agent 需要以下 Kubernetes 资源的 get/list/watch 权限：
+metaflow-agent 同步 K8s 资源和 Label 信息时需要以下资源的 get/list/watch 权限：
 - `nodes`
 - `namespaces`
 - `configmaps`
@@ -95,14 +97,18 @@ helm install metaflow -n metaflow metaflow/metaflow --create-namespace
   ```bash
   helm upgrade metaflow -n metaflow -f values-custom.yaml metaflow/metaflow
   ```
-  
+
 # 下载 metaflow-ctl
 
-metaflow-ctl 是管理 MetaFlow 的一个命令行工具，建议下载至 metaflow-server 所在的 K8s Node 上：
+metaflow-ctl 是管理 MetaFlow 的一个命令行工具，建议下载至 metaflow-server 所在的 K8s Node 上，用于后续使用：
 ```bash
 curl -o /usr/bin/metaflow-ctl https://metaflow.oss-cn-beijing.aliyuncs.com/bin/ctl/latest/linux/amd64/metaflow-ctl
 chmod a+x /usr/bin/metaflow-ctl
 ```
+
+# 访问 Grafana 页面
+
+@建昌
 
 # 下一步
 

--- a/zh/02-install/04-multi-k8s.md
+++ b/zh/02-install/04-multi-k8s.md
@@ -4,7 +4,7 @@ title: 监控多个 K8s 集群
 
 # 简介
 
-假设你在一个 K8s 集群中已经部署好了 metaflow-server，本章介绍如何监控其他的 K8s 集群。
+MetaFlow Server 可服务于多个 K8s 集群中的 MetaFlow Agent。假设你在一个 K8s 集群中已经部署好了 Metaflow Server，本章介绍如何监控其他的 K8s 集群。
 
 # 准备工作
 
@@ -29,7 +29,7 @@ end
 
 MetaFlow 使用 K8s 的 CA 文件 MD5 值区分不同的集群，请在不同 K8s 集群的 Pod 中查看 `/run/secrets/kubernetes.io/serviceaccount/ca.crt` 文件，确保不同集群的 CA 文件不同。
 
-假如你的不同 K8s 集群使用了相同的 CA 文件，在多个集群中部署 metaflow-agent 之前，需要利用 `metaflow-ctl domain create` 获取一个集群ID：
+假如你的不同 K8s 集群使用了相同的 CA 文件，在多个集群中部署 metaflow-agent 之前，需要利用 `metaflow-ctl domain create` 获取一个 `K8sClusterID`：
 ```bash
 unset CLUSTER_NAME
 CLUSTER_NAME="k8s-1"  # FIXME: K8s cluster name
@@ -37,7 +37,7 @@ cat << EOF | metaflow-ctl domain create -f -
 name: $CLUSTER_NAME
 type: kubernetes
 EOF
-metaflow-ctl domain list $CLUSTER_NAME  # Get ID
+metaflow-ctl domain list $CLUSTER_NAME  # Get K8sClusterID
 ```
 
 # 部署 metaflow-agent
@@ -53,7 +53,7 @@ helm install metaflow-agent -n metaflow metaflow/metaflow-agent --create-namespa
 ```
 
 我们为 metaflow-server 的 service 设置了 `externalTrafficPolicy=Local` 以优化流量路径，
-因此上述部署过程中会将 metaflow-agent 的 `metaflowServerNodeIps` 配置为 metaflow-server Pod 的 Node IP。
+因此上述部署过程中需要将 metaflow-agent 的 `metaflowServerNodeIps` 配置为 metaflow-server Pod 所在的 Node IP。
 
 注意：
 - 若不同 K8s 集群的 CA 文件一样，部署时需要传入使用 `metaflow-ctl` 获取到的 `kubernetesClusterId`：
@@ -69,7 +69,7 @@ helm install metaflow-agent -n metaflow metaflow/metaflow-agent --create-namespa
   metaflowServerNodeIPS:
   - 10.1.2.3 # FIXME: K8s Node IPs of 
   - 10.4.5.6 # FIXME: K8s Node IPs of 
-  metaflowK8sClusterID: "fffffff" # FIXME: Generate by `metaflow-ctl 
+  metaflowK8sClusterID: "fffffff" # FIXME: Generate by `metaflow-ctl domain create`
   ```
   后续更新可以使用 `-f values-custom.yaml` 参数使用自定义配置：
   ```bash

--- a/zh/02-install/05-legacy-host.md
+++ b/zh/02-install/05-legacy-host.md
@@ -28,14 +28,12 @@ end
 
 # 配置 MetaFlow Server
 
+## 创建 Host Domain
+
 ```bash
 unset DOMAIN_NAME
 DOMAIN_NAME="legacy-host"  # FIXME: domain name
-```
 
-## 创建云平台
-
-```bash
 cat << EOF | metaflow-ctl domain create -f -
 name: $DOMAIN_NAME
 type: agent_sync
@@ -45,19 +43,22 @@ metaflow-ctl domain create -f create_agent_sync_domain.yaml
 
 ## 创建采集器组
 
+创建采集器组：
 ```bash
-metaflow-ctl agent-group create $DOMAIN_NAME
-metaflow-ctl agent-group list $DOMAIN_NAME # Get agent-group ID
+unset AGENT_GROUP
+AGENT_GROUP="legacy-host"  # FIXME: domain name
+
+metaflow-ctl agent-group create $AGENT_GROUP
+metaflow-ctl agent-group list $AGENT_GROUP # Get agent-group ID
 ```
 
-## 创建采集器配置
-
-创建采集器组配置文件 `agent-group-config.yaml` ：
+创建采集器组配置文件 `agent-group-config.yaml`：
 ```yaml
 vtap_group_id: g-ffffff # FIXME: agent-group ID
 platform_enabled: 1
 ```
-创建采集器组配置
+
+创建采集器组配置：
 ```bash
 metaflow-ctl agent-group-config create -f agent-group-config.yaml
 ```

--- a/zh/02-install/06-cloud-host.md
+++ b/zh/02-install/06-cloud-host.md
@@ -4,7 +4,8 @@ title: 监控云服务器
 
 # 简介
 
-MetaFlow 支持监控云服务器，并通过调用云厂商 API 获取资源信息和标签，自动注入到所有观测数据中（AutoTagging）。
+MetaFlow 支持监控云服务器，并通过调用云厂商 API 获取云资源信息，自动注入到所有观测数据中（AutoTagging）。
+注意 MetaFlow Server 必须运行在 K8s 之上，如果你没有 K8s 集群，可参考 [All-in-One 快速部署](./all-in-one/)章节先部署 MetaFlow Server。
 
 # 部署拓扑
 
@@ -32,33 +33,38 @@ end
 MetaFlowServer -->|"get resource & label"| CloudAPI[cloud api service]
 ```
 
-# 支持的公有云
+# 创建公有云 Domain
 
-| 云服务商（英文）    | 云服务商（中文）   | MetaFlow中使用的类型标识    |
+MetaFlow 目前支持如下公有云的资源信息同步（标记为 `TBD` 的正在整理代码中）：
+| 云服务商（英文） | 云服务商（中文） | MetaFlow中使用的类型标识 |
 | ---------------- | ---------------- | ------------------------ |
-| Aliyun           | 阿里云            | aliyun                   |
-| Baidu Cloud      | 百度云            | baidu_bce                |
-| QingCloud        | 青云              | qingcloud                |
+| AWS              | AWS              | `TBD`                    |
+| Aliyun           | 阿里云           | aliyun                   |
+| Baidu Cloud      | 百度云           | baidu\_bce               |
+| Huawei Cloud     | 华为云           | `TBD`                    |
+| Microsoft Azure  | 微软云           | `TBD`                    |
+| QingCloud        | 青云             | qingcloud                |
+| Tencent Cloud    | 腾讯云           | `TBD`                    |
 
-# 配置 MetaFlow Server
-
-通过 `metaflow-ctl domain example <domain_type>` 命令获取创建云平台的配置文件模板。
-
+可通过 `metaflow-ctl domain example <domain_type>` 命令获取创建公有云 Domain 的配置文件模板。
 以阿里云为例：
 ```bash
 metaflow-ctl domain example aliyun > aliyun.yaml
 ```
-修改配置文件模板`aliyun.yaml` ：
+
+修改配置文件 `aliyun.yaml`，填写 AK/SK（需要云资源的只读权限）和资源所在的 Region 信息：
 ```yaml
 name: aliyun
 type: aliyun
 config:
+  # AccessKey Id
   secret_id: xxxxxxxx ## FIXME: your secret_id
   # AccessKey Secret
   secret_key: xxxxxxx ## FIXME: your secret_key
   include_regions: 华北2（北京） ## The region where metaflow is docked, if it is empty, it means all regions, and the regions are separated by commas
 ```
-使用修改好的配置文件创建云平台：
+
+使用修改好的配置文件创建公有云 Domain：
 ```bash
 metaflow-ctl domain create -f aliyun.yaml
 ```
@@ -79,7 +85,6 @@ controller-ips:
 ```
 
 启动 metaflow-agent ：
-
 ```bash
 systemctl enable metaflow-agent
 systemctl restart metaflow-agent

--- a/zh/02-install/07-managed-k8s.md
+++ b/zh/02-install/07-managed-k8s.md
@@ -4,7 +4,7 @@ title: 监控托管 K8s 集群
 
 # 简介
 
-MetaFlow 支持监控云服务商的托管 K8s 集群。与[直接监控 K8s 集群](./single-k8s/)的区别是，通过配置 metaflow-server 调用云厂商 API，可自动向观测数据中注入云资源标签（AutoTagging）。
+MetaFlow 支持监控云服务商的托管 K8s 集群。与[直接监控 K8s 集群](./single-k8s/)的唯一区别是，通过调用云厂商 API，可自动向观测数据中注入云资源的标签（AutoTagging）。
 
 # 部署拓扑
 

--- a/zh/03-auto-tracing/02-spring-boot-demo.md
+++ b/zh/03-auto-tracing/02-spring-boot-demo.md
@@ -9,7 +9,6 @@ title: Spring Boot Demo
 # 部署 Spring Boot Demo
 
 ```bash
-kubectl create namespace bookinfo
 kubectl apply -f https://raw.githubusercontent.com/metaflowys/metaflow-demo/main/sb-jaeger-tracing-demo/sb-jaeger-tracing-demo.yaml
 ```
 

--- a/zh/06-agent-integration/01-tracing/03-opentelemetry.md
+++ b/zh/06-agent-integration/01-tracing/03-opentelemetry.md
@@ -50,6 +50,5 @@ https://github.com/open-telemetry/opentelemetry-demo-webstore
 # 基于 Spring Boot Demo 体验
 
 ```bash
-kubectl create namespace bookinfo
 kubectl apply -f https://raw.githubusercontent.com/metaflowys/metaflow-demo/main/sb-jaeger-tracing-demo/sb-jaeger-tracing-otel-demo.yaml
 ```


### PR DESCRIPTION
@sharang  helm 安装metaflow时会根据安装参数在终端输出几条命令，执行命令就可以获取访问grafana的url和密码，下面是输出示例
```
NODE_PORT=$(kubectl get --namespace metaflow -o jsonpath="{.spec.ports[0].nodePort}" services metaflow-grafana)
NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
echo -e "Grafana URL: http://$NODE_IP:$NODE_PORT  \nGrafana auth: admin:metaflow"
```

执行命令的输出示例：
```
Grafana URL: http://10.1.2.3:31999
Grafana auth: admin:metaflow
```